### PR TITLE
Removal of max-width query of redditImgWrap

### DIFF
--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -355,9 +355,3 @@ blockquote {
 input[type='checkBox'] {
   margin: 0 6px 0 0;
 }
-
-@media screen and (max-width: 1000px) {
-  #redditImgWrap {
-    z-index: 10;
-  }
-}


### PR DESCRIPTION
Removed the media query that sets the z-order of the div `redditImgWrap`.
The "Sort By" functionality while presenting YouTube comments is available again after the removal.

I researched if z-order is important for this specific div, but didn't find any other usages. 
The button never seems to overlap with anything else. 
Issue #15